### PR TITLE
Add campaign data in Voucher validation

### DIFF
--- a/VoucherifySwiftSdk/Classes/Models/VoucherResponse.swift
+++ b/VoucherifySwiftSdk/Classes/Models/VoucherResponse.swift
@@ -4,6 +4,8 @@ import ObjectMapper
 public struct VoucherResponse: Mappable {
 
     public var code: String?
+    public var campaign: String?
+    public var campaignId: String?
     public var valid: Bool?
     public var discount: Discount?
     public var trackingId: String?
@@ -15,6 +17,8 @@ public struct VoucherResponse: Mappable {
     }
     mutating public func mapping(map: Map) {
         code        <- map["code"]
+        campaign    <- map["campaign"]
+        campaignId  <- map["campaign_id"]
         valid       <- map["valid"]
         discount    <- map["discount"]
         trackingId  <- map["tracking_id"]


### PR DESCRIPTION
## Still to be tested!

New optional fields returned in Voucher validation.

Proposal for Changelog: Add `campaign` and `campaign_id` in Voucher validation response